### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "toolbox"
+description = "A collection of utility nodes for ComfyUI, including audio/video processing, file uploads, and AI image generation."
+version = "1.0.0"
+license = {file = "LICENSE"}
+dependencies = ["# ComfyUI-ToolBox requirements", "# 基本依赖", "numpy>=1.20.0", "Pillow>=9.0.0", "torch>=1.10.0", "# AWS S3上传功能", "boto3>=1.26.0", "botocore>=1.29.0", "# 处理文件路径和网络请求", "requests>=2.27.0"]
+
+[project.urls]
+Repository = "https://github.com/synthetai/ComfyUI-ToolBox"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-ToolBox"
+Icon = ""


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

The registry is already integrated with ComfyUI-Manager, and we want it to be the default place users install nodes from eventually. We do a security-scan of every node to improve safety. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!